### PR TITLE
Support for universal (arm64, x86_64) frameworks on catalyst and simulator

### DIFF
--- a/External/cmake/iOS.cmake
+++ b/External/cmake/iOS.cmake
@@ -85,7 +85,7 @@ if (NOT DEFINED IOS_PLATFORM)
 endif ()
 set (IOS_PLATFORM ${IOS_PLATFORM} CACHE STRING "Type of iOS Platform")
 
-# Hidden visibilty is required for cxx on iOS 
+# Hidden visibilty is required for cxx on iOS
 if (${IOS_PLATFORM} STREQUAL "CATALYST")
 	set (CMAKE_C_FLAGS_INIT "-target x86_64-apple-ios-macabi")
 	set (CMAKE_CXX_FLAGS_INIT "-fvisibility=hidden -fvisibility-inlines-hidden -target x86_64-apple-ios-macabi")
@@ -153,7 +153,7 @@ set (CMAKE_IOS_DEVELOPER_ROOT ${CMAKE_IOS_DEVELOPER_ROOT} CACHE PATH "Location o
 # Find and use the most recent iOS sdk unless specified manually with CMAKE_IOS_SDK_ROOT
 if (NOT DEFINED CMAKE_IOS_SDK_ROOT)
 	file (GLOB _CMAKE_IOS_SDKS "${CMAKE_IOS_DEVELOPER_ROOT}/SDKs/*")
-	if (_CMAKE_IOS_SDKS) 
+	if (_CMAKE_IOS_SDKS)
 		list (SORT _CMAKE_IOS_SDKS)
 		list (REVERSE _CMAKE_IOS_SDKS)
 		list (GET _CMAKE_IOS_SDKS 0 CMAKE_IOS_SDK_ROOT)
@@ -167,11 +167,11 @@ set (CMAKE_IOS_SDK_ROOT ${CMAKE_IOS_SDK_ROOT} CACHE PATH "Location of the select
 # Set the sysroot default to the most recent SDK
 set (CMAKE_OSX_SYSROOT ${CMAKE_IOS_SDK_ROOT} CACHE PATH "Sysroot used for iOS support")
 
-# set the architecture for iOS 
+# set the architecture for iOS
 if (${IOS_PLATFORM} STREQUAL "OS")
     set (IOS_ARCH armv7;arm64)
 elseif (${IOS_PLATFORM} STREQUAL "SIMULATOR" OR ${IOS_PLATFORM} STREQUAL "CATALYST")
-    set (IOS_ARCH x86_64)
+    set (IOS_ARCH x86_64;arm64)
 endif ()
 
 set (CMAKE_OSX_ARCHITECTURES ${IOS_ARCH} CACHE STRING  "Build architecture for iOS")

--- a/External/openssl-config/ios-and-catalyst.conf
+++ b/External/openssl-config/ios-and-catalyst.conf
@@ -14,4 +14,8 @@ my %targets = (
         inherit_from => [ "darwin64-x86_64-cc" ],
         cflags => add("-target x86_64-apple-ios-macabi"),
     },
+    "openssl-catalyst-arm" => {
+        inherit_from => [ "darwin64-arm64-cc" ],
+        cflags => add("-target aarch64-apple-ios-macabi"),
+    },
 )

--- a/External/openssl-config/ios-and-catalyst.conf
+++ b/External/openssl-config/ios-and-catalyst.conf
@@ -10,6 +10,13 @@ my %targets = (
     "openssl-iossimulator" => {
         inherit_from => [ "iossimulator-xcrun" ],
     },
+    "openssl-iossimulator-arm" => {
+        inherit_from => [ "iossimulator-xcrun" ],
+        cflags           => add("-arch arm64"),
+        bn_ops           => "SIXTY_FOUR_BIT_LONG RC4_CHAR",
+        asm_arch         => 'aarch64',
+        perlasm_scheme   => "ios64",
+    },
     "openssl-catalyst" => {
         inherit_from => [ "darwin64-x86_64-cc" ],
         cflags => add("-target x86_64-apple-ios-macabi"),

--- a/bin/build_libgit2.sh
+++ b/bin/build_libgit2.sh
@@ -6,7 +6,7 @@
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is 
+# copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
 #
 # The above copyright notice and this permission notice shall be included in
@@ -52,17 +52,17 @@ do
     case $PLATFORM in
         "OS" )
             OPENSSL_ROOT_DIR=$ROOT_PATH/build/openssl/ios
-            OPENSSL_LIBRARIES_DIR=$ROOT_PATH/build/openssl/lib
+            OPENSSL_LIBRARIES_DIR=$ROOT_PATH/build/openssl/lib-ios
             ;;
 
         "SIMULATOR" )
             OPENSSL_ROOT_DIR=$ROOT_PATH/build/openssl/iossimulator
-            OPENSSL_LIBRARIES_DIR=$OPENSSL_ROOL_DIR/lib
+            OPENSSL_LIBRARIES_DIR=$ROOT_PATH/build/openssl/lib-iossimulator
             ;;
 
         "CATALYST" )
             OPENSSL_ROOT_DIR=$ROOT_PATH/build/openssl/catalyst
-            OPENSSL_LIBRARIES_DIR=$OPENSSL_ROOT_DIR/lib
+            OPENSSL_LIBRARIES_DIR=$ROOT_PATH/build/openssl/lib-catalyst
             ;;
     esac
 

--- a/bin/build_libssh2.sh
+++ b/bin/build_libssh2.sh
@@ -6,7 +6,7 @@
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is 
+# copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
 #
 # The above copyright notice and this permission notice shall be included in
@@ -51,20 +51,20 @@ do
     case $PLATFORM in
         "OS" )
             OPENSSL_ROOT_DIR=$ROOT_PATH/build/openssl/ios
-            OPENSSL_CRYPTO_LIBRARY=$ROOT_PATH/build/openssl/lib/libcrypto.a
-            OPENSSL_SSL_LIBRARY=$ROOT_PATH/build/openssl/lib/libssl.a
+            OPENSSL_CRYPTO_LIBRARY=$ROOT_PATH/build/openssl/lib-ios/libcrypto.a
+            OPENSSL_SSL_LIBRARY=$ROOT_PATH/build/openssl/lib-ios/libssl.a
             ;;
 
         "SIMULATOR" )
             OPENSSL_ROOT_DIR=$ROOT_PATH/build/openssl/iossimulator
-            OPENSSL_CRYPTO_LIBRARY=$OPENSSL_ROOT_DIR/lib/libcrypto.a
-            OPENSSL_SSL_LIBRARY=$OPENSSL_ROOT_DIR/lib/libssl.a
+            OPENSSL_CRYPTO_LIBRARY=$ROOT_PATH/build/openssl/lib-iossimulator/libcrypto.a
+            OPENSSL_SSL_LIBRARY=$ROOT_PATH/build/openssl/lib-iossimulator/libssl.a
             ;;
 
         "CATALYST" )
             OPENSSL_ROOT_DIR=$ROOT_PATH/build/openssl/catalyst
-            OPENSSL_CRYPTO_LIBRARY=$OPENSSL_ROOT_DIR/lib/libcrypto.a
-            OPENSSL_SSL_LIBRARY=$OPENSSL_ROOT_DIR/lib/libssl.a
+            OPENSSL_CRYPTO_LIBRARY=$ROOT_PATH/build/openssl/lib-catalyst/libcrypto.a
+            OPENSSL_SSL_LIBRARY=$ROOT_PATH/build/openssl/lib-catalyst/libssl.a
             ;;
     esac
 

--- a/bin/build_openssl.sh
+++ b/bin/build_openssl.sh
@@ -6,7 +6,7 @@
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is 
+# copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
 #
 # The above copyright notice and this permission notice shall be included in
@@ -32,11 +32,11 @@ pushd $SCRIPT_DIR/.. > /dev/null
 ROOT_PATH=$PWD
 popd > /dev/null
 
-CONFIGURATIONS="ios ios64 iossimulator catalyst"
+CONFIGURATIONS="ios ios64 iossimulator catalyst catalyst-arm"
 for CONFIGURATION in $CONFIGURATIONS
 do
     echo "Building OpenSSL for $CONFIGURATION"
-    
+
     rm -rf /tmp/openssl
     cp -r External/openssl /tmp/
 
@@ -83,6 +83,7 @@ xcodebuild -create-xcframework \
     -library $ROOT_PATH/build/openssl/lib/libcrypto.a \
     -library $ROOT_PATH/build/openssl/iossimulator/lib/libcrypto.a \
     -library $ROOT_PATH/build/openssl/catalyst/lib/libcrypto.a \
+    -library $ROOT_PATH/build/openssl/catalyst-arm/lib/libcrypto.a \
     -output $LIBCRYPTO_PATH
 
 xcodebuild -create-xcframework \
@@ -92,6 +93,8 @@ xcodebuild -create-xcframework \
     -headers $ROOT_PATH/build/openssl/iossimulator/include \
     -library $ROOT_PATH/build/openssl/catalyst/lib/libssl.a \
     -headers $ROOT_PATH/build/openssl/catalyst/include \
+    -library $ROOT_PATH/build/openssl/catalyst-arm/lib/libssl.a \
+    -headers $ROOT_PATH/build/openssl/catalyst-arm/include \
     -output $LIBSSL_PATH
 
 pushd $LIB_PATH/libcrypto > /dev/null

--- a/bin/build_openssl.sh
+++ b/bin/build_openssl.sh
@@ -32,7 +32,7 @@ pushd $SCRIPT_DIR/.. > /dev/null
 ROOT_PATH=$PWD
 popd > /dev/null
 
-CONFIGURATIONS="ios ios64 iossimulator catalyst catalyst-arm"
+CONFIGURATIONS="ios ios64 iossimulator iossimulator-arm catalyst catalyst-arm"
 for CONFIGURATION in $CONFIGURATIONS
 do
     echo "Building OpenSSL for $CONFIGURATION"
@@ -58,7 +58,7 @@ done
 
 echo "Creating the universal library for iOS"
 
-OUTPUT_PATH=$ROOT_PATH/build/openssl/lib
+OUTPUT_PATH=$ROOT_PATH/build/openssl/lib-ios
 rm -rf $OUTPUT_PATH
 mkdir -p $OUTPUT_PATH
 lipo -create \
@@ -68,6 +68,34 @@ lipo -create \
 lipo -create \
     $ROOT_PATH/build/openssl/ios/lib/libssl.a \
     $ROOT_PATH/build/openssl/ios64/lib/libssl.a \
+    -output $OUTPUT_PATH/libssl.a
+
+echo "Creating the universal library for iOS Simulator"
+
+OUTPUT_PATH=$ROOT_PATH/build/openssl/lib-iossimulator
+rm -rf $OUTPUT_PATH
+mkdir -p $OUTPUT_PATH
+lipo -create \
+    $ROOT_PATH/build/openssl/iossimulator/lib/libcrypto.a \
+    $ROOT_PATH/build/openssl/iossimulator-arm/lib/libcrypto.a \
+    -output $OUTPUT_PATH/libcrypto.a
+lipo -create \
+    $ROOT_PATH/build/openssl/iossimulator/lib/libssl.a \
+    $ROOT_PATH/build/openssl/iossimulator-arm/lib/libssl.a \
+    -output $OUTPUT_PATH/libssl.a
+
+echo "Creating the universal library for Catalyst"
+
+OUTPUT_PATH=$ROOT_PATH/build/openssl/lib-catalyst
+rm -rf $OUTPUT_PATH
+mkdir -p $OUTPUT_PATH
+lipo -create \
+    $ROOT_PATH/build/openssl/catalyst/lib/libcrypto.a \
+    $ROOT_PATH/build/openssl/catalyst-arm/lib/libcrypto.a \
+    -output $OUTPUT_PATH/libcrypto.a
+lipo -create \
+    $ROOT_PATH/build/openssl/catalyst/lib/libssl.a \
+    $ROOT_PATH/build/openssl/catalyst-arm/lib/libssl.a \
     -output $OUTPUT_PATH/libssl.a
 
 echo "Creating the OpenSSL XCFrameworks"
@@ -80,21 +108,18 @@ rm -rf $LIBSSL_PATH
 mkdir -p $LIB_PATH
 
 xcodebuild -create-xcframework \
-    -library $ROOT_PATH/build/openssl/lib/libcrypto.a \
-    -library $ROOT_PATH/build/openssl/iossimulator/lib/libcrypto.a \
-    -library $ROOT_PATH/build/openssl/catalyst/lib/libcrypto.a \
-    -library $ROOT_PATH/build/openssl/catalyst-arm/lib/libcrypto.a \
+    -library $ROOT_PATH/build/openssl/lib-ios/libcrypto.a \
+    -library $ROOT_PATH/build/openssl/lib-iossimulator/libcrypto.a \
+    -library $ROOT_PATH/build/openssl/lib-catalyst/libcrypto.a \
     -output $LIBCRYPTO_PATH
 
 xcodebuild -create-xcframework \
-    -library $ROOT_PATH/build/openssl/lib/libssl.a \
-    -headers $ROOT_PATH/build/openssl/ios/include \
-    -library $ROOT_PATH/build/openssl/iossimulator/lib/libssl.a \
+    -library $ROOT_PATH/build/openssl/lib-ios/libssl.a \
+    -headers $ROOT_PATH/build/openssl/ios64/include \
+    -library $ROOT_PATH/build/openssl/lib-iossimulator/libssl.a \
     -headers $ROOT_PATH/build/openssl/iossimulator/include \
-    -library $ROOT_PATH/build/openssl/catalyst/lib/libssl.a \
+    -library $ROOT_PATH/build/openssl/lib-catalyst/libssl.a \
     -headers $ROOT_PATH/build/openssl/catalyst/include \
-    -library $ROOT_PATH/build/openssl/catalyst-arm/lib/libssl.a \
-    -headers $ROOT_PATH/build/openssl/catalyst-arm/include \
     -output $LIBSSL_PATH
 
 pushd $LIB_PATH/libcrypto > /dev/null


### PR DESCRIPTION
Existing scripts target only `x86_64` on catalyst and simulator. This change includes `arm64` builds and updates scripts to lipo them together.

I haven't been able to test these on an Apple Silicon Mac yet, but Xcode seems happy using them to build universal catalyst apps.

